### PR TITLE
feat: support configurable ollama model

### DIFF
--- a/RAG/backend/.env.example
+++ b/RAG/backend/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables for the RAG backend
+# Set the Ollama model to use. Defaults to SmolLM3-Q4_K_M if not set.
+OLLAMA_MODEL=SmolLM3-Q4_K_M

--- a/RAG/backend/src/services/chat_services.py
+++ b/RAG/backend/src/services/chat_services.py
@@ -16,7 +16,7 @@ class ChatService:
         self._load_env()
         
         # 환경변수에서 모델명 가져오기 (기본값: 전달받은 model_name)
-        self.model_name = os.getenv("SmolLM3-Q4_K_M", model_name)
+        self.model_name = os.getenv("OLLAMA_MODEL", model_name)
         
         # Ollama 모델 초기화
         self.model = OllamaChatModel(


### PR DESCRIPTION
## Summary
- read the Ollama model name from `OLLAMA_MODEL` env var
- provide `.env.example` with `OLLAMA_MODEL` placeholder

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892d8ee99f88322980649482fc2ceaf