### PR TITLE
Add Qdrant service to RAG compose

### DIFF
--- a/RAG/rag-compose.yaml
+++ b/RAG/rag-compose.yaml
@@ -9,6 +9,14 @@ services:
     environment:
       - OLLAMA_HOST=0.0.0.0
     restart: unless-stopped
+  qdrant:
+    image: qdrant/qdrant:latest
+    container_name: qdrant
+    ports:
+      - "6333:6333"
+    volumes:
+      - ./backend/qdrant:/qdrant/storage
+    restart: unless-stopped
   rag-api:
     build:
       context: ./backend
@@ -23,3 +31,4 @@ services:
       - "8000:8000"
     depends_on:
       - ollama
+      - qdrant


### PR DESCRIPTION
## Summary
- add Qdrant vector store service to rag-compose
- link rag-api to qdrant via depends_on

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892d8d901f08322ad88a23b808eb2ff